### PR TITLE
Fix typo for Quark's Gray Parrot Egg

### DIFF
--- a/src/generated/resources/data/forge/tags/items/eggs.json
+++ b/src/generated/resources/data/forge/tags/items/eggs.json
@@ -30,7 +30,7 @@
       "required": false
     },
     {
-      "id": "quark:egg_parrot_grey",
+      "id": "quark:egg_parrot_gray",
       "required": false
     },
     {


### PR DESCRIPTION
The ID of Quark's Gray Parrot Egg is `quark:parrot_egg_gray` , not "_grey_". This PR fixes that.

Feel free to modify the PR, I have no idea why it decides to trim the new line at the end.